### PR TITLE
Fix for Vehicle classes constructor

### DIFF
--- a/Slipe/Core/Lua/Backing/SlipeMTADfinitions/client.lua
+++ b/Slipe/Core/Lua/Backing/SlipeMTADfinitions/client.lua
@@ -44,6 +44,7 @@ System.define("Slipe.MtaDefinitions.MtaClient", {
 	DetonateSatchels = detonateSatchels,
 	TakePlayerMoney = takePlayerMoney,
 	GetNetworkStats = function(...) local results = {getNetworkStats(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
+	CreateVehicle = function(...) local results = {createVehicle(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	BlowVehicle = blowVehicle,
 	GetRadioChannel = function(...) local results = {getRadioChannel(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	GetRadioChannelName = function(...) local results = {getRadioChannelName(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,

--- a/Slipe/Core/Lua/Backing/SlipeMTADfinitions/server.lua
+++ b/Slipe/Core/Lua/Backing/SlipeMTADfinitions/server.lua
@@ -239,6 +239,7 @@ System.define("Slipe.MtaDefinitions.MtaServer", {
 	GetNetworkStats = function(...) local results = {getNetworkStats(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	GetServerConfigSetting = function(...) local results = {getServerConfigSetting(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	SetServerConfigSetting = setServerConfigSetting,
+	CreateVehicle = function(...) local results = {createVehicle(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	BlowVehicle = blowVehicle,
 	AddVehicleSirens = addVehicleSirens,
 	GetModelHandling = function(...) local results = {getModelHandling(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,

--- a/Slipe/Core/Lua/Backing/SlipeMTADfinitions/shared.lua
+++ b/Slipe/Core/Lua/Backing/SlipeMTADfinitions/shared.lua
@@ -290,7 +290,6 @@ System.define("Slipe.MtaDefinitions.MtaShared", {
 	AddVehicleUpgrade = addVehicleUpgrade,
 	GetTrainPosition = function(...) local results = {getTrainPosition(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	FixVehicle = fixVehicle,
-	CreateVehicle = function(...) local results = {createVehicle(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,
 	DetachTrailerFromVehicle = detachTrailerFromVehicle,
 	GetTrainDirection = getTrainDirection,
 	GetTrainSpeed = function(...) local results = {getTrainSpeed(...)} if results[1] == false then System.throw(Slipe.MtaDefinitions.MtaException()) return end return unpack(results) end,

--- a/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
@@ -181,13 +181,13 @@ namespace Slipe.Client.Vehicles
         /// <summary>
         /// Create a vehicle from a model at a position
         /// </summary>
-        public Vehicle(BaseVehicleModel model, Vector3 position)
+        public Vehicle(SharedVehicleModel model, Vector3 position)
             : this(model, position, Vector3.Zero) { }
 
         /// <summary>
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
-        public Vehicle(BaseVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
+        public Vehicle(SharedVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
             : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
         #endregion
 

--- a/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
@@ -188,7 +188,7 @@ namespace Slipe.Client.Vehicles
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
         public Vehicle(SharedVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
-            : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
+            : this(MtaClient.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, variant1, variant2)) { }
         #endregion
 
         #region Misc. Methods

--- a/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeClient/Vehicles/Vehicle.cs
@@ -188,7 +188,7 @@ namespace Slipe.Client.Vehicles
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
         public Vehicle(BaseVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
-            : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
+            : this(MtaClient.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, variant1, variant2)) { }
         #endregion
 
         #region Misc. Methods

--- a/Slipe/Core/Source/SlipeMTADefinitions/MTAClient.cs
+++ b/Slipe/Core/Source/SlipeMTADefinitions/MTAClient.cs
@@ -47,7 +47,8 @@ namespace Slipe.MtaDefinitions {
 		public static bool TakePlayerMoney (int amount){ throw new NotImplementedException(); }
 		public static bool DetonateSatchels (){ throw new NotImplementedException(); }
 		public static dynamic GetNetworkStats (){ throw new NotImplementedException(); }
-		public static bool BlowVehicle (MtaElement vehicleToBlow){ throw new NotImplementedException(); }
+        public static MtaElement CreateVehicle(int model, float x, float y, float z, float rx, float ry, float rz, string numberplate, int variant1, int variant2) { throw new NotImplementedException(); }
+        public static bool BlowVehicle (MtaElement vehicleToBlow){ throw new NotImplementedException(); }
 		public static bool DgsProgressBarSetProgress (MtaElement theProgressbar, float progress){ throw new NotImplementedException(); }
 		public static string GetRadioChannelName (int id){ throw new NotImplementedException(); }
 		public static bool GetSFXStatus (string audioContainer){ throw new NotImplementedException(); }

--- a/Slipe/Core/Source/SlipeMTADefinitions/MTAServer.cs
+++ b/Slipe/Core/Source/SlipeMTADefinitions/MTAServer.cs
@@ -242,7 +242,8 @@ namespace Slipe.MtaDefinitions {
 		public static dynamic GetNetworkStats (MtaElement thePlayer){ throw new NotImplementedException(); }
 		public static string GetServerConfigSetting (string name){ throw new NotImplementedException(); }
 		public static bool SetServerConfigSetting (string name, string value, bool bSave){ throw new NotImplementedException(); }
-		public static bool AddVehicleSirens (MtaElement theVehicle, int sirenCount, int sirenType, bool argument_360flag, bool checkLosFlag, bool useRandomiser, bool silentFlag){ throw new NotImplementedException(); }
+        public static MtaElement CreateVehicle(int model, float x, float y, float z, float rx, float ry, float rz, string numberplate, bool bDirection, int variant1, int variant2) { throw new NotImplementedException(); }
+        public static bool AddVehicleSirens (MtaElement theVehicle, int sirenCount, int sirenType, bool argument_360flag, bool checkLosFlag, bool useRandomiser, bool silentFlag){ throw new NotImplementedException(); }
 		public static bool BlowVehicle (MtaElement vehicleToBlow, bool explode){ throw new NotImplementedException(); }
 		public static dynamic GetModelHandling (int modelId){ throw new NotImplementedException(); }
 		public static Tuple<float, float, float> GetVehicleRespawnPosition (MtaElement theVehicle){ throw new NotImplementedException(); }

--- a/Slipe/Core/Source/SlipeMTADefinitions/MTAShared.cs
+++ b/Slipe/Core/Source/SlipeMTADefinitions/MTAShared.cs
@@ -290,7 +290,6 @@ namespace Slipe.MtaDefinitions {
 		public static string Utf8_gsub (string input, string pattern, dynamic replace, int match_limit){ throw new NotImplementedException(); }
 		public static int Utf8_width (dynamic input, bool ambi_is_double, int default_width){ throw new NotImplementedException(); }
 		public static bool DetachTrailerFromVehicle (MtaElement theVehicle, MtaElement theTrailer){ throw new NotImplementedException(); }
-		public static MtaElement CreateVehicle (int model, float x, float y, float z, float rx, float ry, float rz, string numberplate, bool bDirection, int variant1, int variant2){ throw new NotImplementedException(); }
 		public static bool FixVehicle (MtaElement theVehicle){ throw new NotImplementedException(); }
 		public static dynamic GetOriginalHandling (int modelID){ throw new NotImplementedException(); }
 		public static bool GetTrainDirection (MtaElement train){ throw new NotImplementedException(); }

--- a/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
@@ -168,7 +168,7 @@ namespace Slipe.Server.Vehicles
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
         public Vehicle(SharedVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
-            : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
+            : this(MtaServer.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
 
         #endregion
 

--- a/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
@@ -161,13 +161,13 @@ namespace Slipe.Server.Vehicles
         /// <summary>
         /// Create a vehicle from a model at a position
         /// </summary>
-        public Vehicle(BaseVehicleModel model, Vector3 position) 
+        public Vehicle(SharedVehicleModel model, Vector3 position) 
             : this(model, position, Vector3.Zero) { }
 
         /// <summary>
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
-        public Vehicle(BaseVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
+        public Vehicle(SharedVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
             : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
 
         #endregion

--- a/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
+++ b/Slipe/Core/Source/SlipeServer/Vehicles/Vehicle.cs
@@ -168,7 +168,7 @@ namespace Slipe.Server.Vehicles
         /// Create a vehicle using all createVehicle arguments
         /// </summary>
         public Vehicle(BaseVehicleModel model, Vector3 position, Vector3 rotation, string numberplate = "", int variant1 = 1, int variant2 = 1)
-            : this(MtaShared.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
+            : this(MtaServer.CreateVehicle(model.ID, position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, numberplate, false, variant1, variant2)) { }
 
         #endregion
 


### PR DESCRIPTION
Changed the expected object type in the Vehicle class constructors for both SlipeClient and SlipeServer.

Also fixed the difference between creating vehicles server side and client side. Per documentation from mtasa: https://wiki.multitheftauto.com/wiki/CreateVehicle, this function has an unused and unknown parameter called **bDirection** which is only used server side. In Slipe's source code there was only one definition of CreateVehicle shared between Server and Client.

When attempting to create a Client vehicle the following error was thrown in the debug console for the client side script:

```
[2019-05-14 22:54:57] WARNING: roleplay\Slipe\Core\Lua\Backing\SlipeMTADfinitions\shared.lua:293: Bad argument @ 'createVehicle' [Expected number at argument 9, got boolean]
[2019-05-14 22:54:57] ERROR: roleplay\Slipe\Core\Lua\SystemComponents\Core.lua:67: Slipe.MtaDefinitions.MtaException: MTA Has thrown an exception
stack traceback:
	...Slipe\Core\Lua\Backing\SlipeMTADfinitions\shared.lua:293: in function 'CreateVehicle'
	...piled\Client\Source\SlipeClient\Vehicles\Vehicle.lua:42: in function '__ctor3__'
	...piled\Client\Source\SlipeClient\Vehicles\Vehicle.lua:36: in function '?'
	roleplay\Slipe\Core\Lua\SystemComponents\Core.lua:960: in function 'new'
	roleplay\Dist\Client\Client.lua:52: in function '__ctor__'
	roleplay\Slipe\Core\Lua\SystemComponents\Core.lua:60: in function 'CreateVehicle'
	roleplay\Dist\Client\Client.lua:39: in function 'result'
	roleplay\Slipe\Lua\Main\main.lua:57: in function 'runEntryPoint'
	roleplay\Slipe\Lua\Main\main.lua:59: in main chunk
```