### PR TITLE
Fix wrong name in font quality enum

### DIFF
--- a/Slipe/Core/Source/SlipeClient/Dx/FontQuality.cs
+++ b/Slipe/Core/Source/SlipeClient/Dx/FontQuality.cs
@@ -15,6 +15,6 @@ namespace Slipe.Client.Enums
         NonAntiAliased,
         AntiAliased,
         ClearType,
-        ClearType_Neutral
+        ClearType_Natural
     }
 }


### PR DESCRIPTION
https://wiki.multitheftauto.com/wiki/DxCreateFont