### PR TITLE
EventArgs classes that make use of MouseButton and MouseButtonState enums

### DIFF
--- a/Slipe/Core/Source/SlipeClient/Gui/Events/OnClickEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/Events/OnClickEventArgs.cs
@@ -23,10 +23,10 @@ namespace Slipe.Client.Gui.Events
         /// </summary>
         public Vector2 ScreenPosition { get; }
 
-        internal OnClickEventArgs(dynamic button, dynamic state, dynamic x, dynamic y)
+        internal OnClickEventArgs(dynamic mouseButton, dynamic buttonState, dynamic x, dynamic y)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)button);
-            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)state);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
+            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState, true);
             ScreenPosition = new Vector2((float)x, (float)y);
         }
     }

--- a/Slipe/Core/Source/SlipeClient/Gui/Events/OnDoubleClickEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/Events/OnDoubleClickEventArgs.cs
@@ -23,10 +23,10 @@ namespace Slipe.Client.Gui.Events
         /// </summary>
         public Vector2 ScreenPosition { get; }
 
-        internal OnDoubleClickEventArgs(dynamic button, dynamic state, dynamic x, dynamic y)
+        internal OnDoubleClickEventArgs(dynamic mouseButton, dynamic buttonState, dynamic x, dynamic y)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)button);
-            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)state);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
+            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState, true);
             ScreenPosition = new Vector2((float)x, (float)y);
         }
     }

--- a/Slipe/Core/Source/SlipeClient/Gui/Events/OnMouseDownEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/Events/OnMouseDownEventArgs.cs
@@ -18,9 +18,9 @@ namespace Slipe.Client.Gui.Events
         /// </summary>
         public Vector2 ScreenPosition { get; }
 
-        internal OnMouseDownEventArgs(dynamic button, dynamic x, dynamic y)
+        internal OnMouseDownEventArgs(dynamic mouseButton, dynamic x, dynamic y)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)button);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
             ScreenPosition = new Vector2((float)x, (float)y);
         }
     }

--- a/Slipe/Core/Source/SlipeClient/Gui/Events/OnMouseUpEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/Events/OnMouseUpEventArgs.cs
@@ -18,9 +18,9 @@ namespace Slipe.Client.Gui.Events
         /// </summary>
         public Vector2 ScreenPosition { get; }
 
-        internal OnMouseUpEventArgs(dynamic button, dynamic x, dynamic y)
+        internal OnMouseUpEventArgs(dynamic mouseButton, dynamic x, dynamic y)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)button);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
             ScreenPosition = new Vector2((float)x, (float)y);
         }
     }

--- a/Slipe/Core/Source/SlipeClient/IO/Events/OnClickEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/IO/Events/OnClickEventArgs.cs
@@ -37,8 +37,8 @@ namespace Slipe.Client.IO.Events
 
         internal OnClickEventArgs(dynamic mouseButton, dynamic buttonState, dynamic sx, dynamic sy, dynamic wx, dynamic wy, dynamic wz, MtaElement clickedElement)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton);
-            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
+            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState, true);
             ClickedElement = ElementManager.Instance.GetElement<PhysicalElement>(clickedElement);
             WorldPosition = new Vector3((float) wx, (float) wy, (float) wz);
             ScreenPosition = new Vector2((float)sx, (float)sy);

--- a/Slipe/Core/Source/SlipeClient/IO/Events/OnDoubleClickEventArgs.cs
+++ b/Slipe/Core/Source/SlipeClient/IO/Events/OnDoubleClickEventArgs.cs
@@ -32,7 +32,7 @@ namespace Slipe.Client.IO.Events
 
         internal OnDoubleClickEventArgs(dynamic mouseButton, dynamic sx, dynamic sy, dynamic wx, dynamic wy, dynamic wz, MtaElement clickedElement)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
             ClickedElement = ElementManager.Instance.GetElement<PhysicalElement>(clickedElement);
             WorldPosition = new Vector3((float)wx, (float)wy, (float)wz);
             ScreenPosition = new Vector2((float)sx, (float)sy);

--- a/Slipe/Core/Source/SlipeServer/Peds/Events/OnClickEventArgs.cs
+++ b/Slipe/Core/Source/SlipeServer/Peds/Events/OnClickEventArgs.cs
@@ -37,8 +37,8 @@ namespace Slipe.Server.Peds.Events
 
         internal OnClickEventArgs(dynamic mouseButton, dynamic buttonState, MtaElement clickedElement, dynamic wx, dynamic wy, dynamic wz, dynamic sx, dynamic sy)
         {
-            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton);
-            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState);
+            MouseButton = (MouseButton)Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
+            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState, true);
             ClickedElement = ElementManager.Instance.GetElement<PhysicalElement>(clickedElement);
             WorldPosition = new Vector3((float) wx, (float) wy, (float) wz);
             ScreenPosition = new Vector2((float)sx, (float)sy);

--- a/Slipe/Core/Source/SlipeShared/Elements/Events/OnClickedEventArgs.cs
+++ b/Slipe/Core/Source/SlipeShared/Elements/Events/OnClickedEventArgs.cs
@@ -32,8 +32,8 @@ namespace Slipe.Shared.Elements.Events
 
         internal OnClickedEventArgs(dynamic mouseButton, dynamic buttonState, MtaElement clickedBy, dynamic x, dynamic y, dynamic z)
         {
-            MouseButton = (MouseButton) Enum.Parse(typeof(MouseButton), (string)mouseButton);
-            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)mouseButton);
+            MouseButton = (MouseButton) Enum.Parse(typeof(MouseButton), (string)mouseButton, true);
+            MouseButtonState = (MouseButtonState)Enum.Parse(typeof(MouseButtonState), (string)buttonState, true);
             Player = ElementManager.Instance.GetElement<SharedPed>(clickedBy);
             Position = new Vector3((float)x, (float)y, (float)z);
         }


### PR DESCRIPTION
I've found some issues regarding `*EventArgs` classes for events related to the mouse input.
My fix is to add the third param to Enum.Parse which ignores the case of the searched item.

Also found a typo in the `OnClickedEventArgs` class on the `MouseButonState` field. It tried to return a value from the `MouseButtonState` enum based on the `mouseButton` param and not `buttonState` as it should.

Took the liberty to rename some params for better readability.