### PR TITLE
Small fix for GridItem

### DIFF
--- a/Slipe/Core/Source/SlipeClient/Gui/GridItem.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/GridItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Slipe.Client.IO;
 using Slipe.MtaDefinitions;
 using Slipe.Shared.Utilities;
 
@@ -12,7 +13,6 @@ namespace Slipe.Client.Gui
     public class GridItem
     {
         private GridList glist;
-        private bool textSet;
 
         #region Properties
 
@@ -54,7 +54,6 @@ namespace Slipe.Client.Gui
             set
             {
                 MtaClient.GuiGridListSetItemText(glist.MTAElement, Row.ID, Column.ID, value, false, false);
-                textSet = true;
             }
         }
 
@@ -65,14 +64,18 @@ namespace Slipe.Client.Gui
         {
             get
             {
-                if (!textSet)
+                if (string.IsNullOrEmpty(Content))
+                {
                     Content = "";
+                }
                 return MtaClient.GuiGridListGetItemData(glist.MTAElement, Row.ID, Column.ID);
             }
             set
             {
-                if (!textSet)
+                if(string.IsNullOrEmpty(Content))
+                {
                     Content = "";
+                }
                 MtaClient.GuiGridListSetItemData(glist.MTAElement, Row.ID, Column.ID, value);
             }
         }

--- a/Slipe/Core/Source/SlipeClient/Gui/GridItem.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/GridItem.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Slipe.Client.IO;
 using Slipe.MtaDefinitions;
 using Slipe.Shared.Utilities;
 


### PR DESCRIPTION
Apparently the `bool textSet` wasn't working properly for some weird reason and the `Content` was being replaced with an empty string every time `get` was called for `Data`.