### PR TITLE
Fix key binding on methods

### DIFF
--- a/Slipe/Core/Source/SlipeServer/IO/Input.cs
+++ b/Slipe/Core/Source/SlipeServer/IO/Input.cs
@@ -4,13 +4,12 @@ using Slipe.Shared.Elements;
 using Slipe.Shared.IO;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Slipe.Server.IO
 {
     public static class Input
     {
-        private static Dictionary<Action<Player, string, KeyState>, Action<MtaElement, string, string>> closures 
+        private static Dictionary<Action<Player, string, KeyState>, Action<MtaElement, string, string>> closures
             = new Dictionary<Action<Player, string, KeyState>, Action<MtaElement, string, string>>();
 
         /// <summary>
@@ -51,7 +50,7 @@ namespace Slipe.Server.IO
         {
             Action<MtaElement, string, string> rawClosure = (MtaElement element, string command, string state) =>
             {
-                handler((Player)ElementManager.Instance.GetElement(element), command, Enum.Parse<KeyState>(state));
+                handler((Player)ElementManager.Instance.GetElement(element), command, (KeyState)Enum.Parse(typeof(KeyState), state, true));
             };
             closures[handler] = rawClosure;
             return MtaServer.BindKey(player.MTAElement, key, state.ToString().ToLower(), rawClosure);


### PR DESCRIPTION
Binding a key to a method using code similar to this:

`Input.BindKey(player, "e", Slipe.Shared.IO.KeyState.Down, VehiclesCommands.StartEngine);`

throws this error in the server console:

```
[2019-09-22 09:47:33] ERROR: roleplay\Slipe\Core\Lua\SystemComponents\Core.lua:64: System.ArgumentException: Arg_MustBeEnum
stack traceback:
	roleplay\Slipe\Core\Lua\SystemComponents\Enum.lua:57: in function 'tryParseEnum'
	roleplay\Slipe\Core\Lua\SystemComponents\Enum.lua:154: in function 'Parse'
	...\Lua\Compiled\Server\Source\SlipeServer\IO\Input.lua:51: in function <...\Lua\Compiled\Server\Source\SlipeServer\IO\Input.lua:49>
```