### PR TITLE
Small fix for GridList Clear method.

### DIFF
--- a/Slipe/Core/Source/SlipeClient/Gui/GridList.cs
+++ b/Slipe/Core/Source/SlipeClient/Gui/GridList.cs
@@ -251,6 +251,8 @@ namespace Slipe.Client.Gui
         /// </summary>
         public bool Clear()
         {
+            rows.Clear();
+            columns.Clear();
             return MtaClient.GuiGridListClear(element);
         }
 


### PR DESCRIPTION
The Dictionaries that hold the Rows and Columns data doesn't get cleared when Clear is called.